### PR TITLE
Fix the tab line face

### DIFF
--- a/.config/doom/config.el
+++ b/.config/doom/config.el
@@ -212,6 +212,7 @@
     (custom-set-faces!
       (list 'agda2-highlight-inductive-constructor-face :foreground (get-theme-color-green theme))
       (list 'git-commit-overlong-summary :foreground (get-theme-color-red theme))
+      (list 'tab-line :inherit)
       )
   )
 )


### PR DESCRIPTION
Previously, the background of the tab line was annoyingly white. Now, the background is inherited from the rest of the frame which integrates it perfectly.

Alternatively, you could set the background to a specific color (e.g., `(list 'tab-line :background "black")`). However, this would probably require separate colors for each theme.